### PR TITLE
Ticket4408 reduce calls to busapps

### DIFF
--- a/exp_db_populator/gatherer.py
+++ b/exp_db_populator/gatherer.py
@@ -13,7 +13,7 @@ import os
 from six.moves import input
 import argparse
 
-POLLING_TIME = 30  # Time in seconds between polling the website
+POLLING_TIME = 60  # Time in seconds between polling the website
 
 
 def correct_name(old_name):
@@ -29,6 +29,7 @@ def correct_name(old_name):
 
 class Gatherer(threading.Thread):
     running = True
+    instruments = {}
 
     def __init__(self, inst_list, db_lock, run_continuous=False):
         threading.Thread.__init__(self)
@@ -38,12 +39,30 @@ class Gatherer(threading.Thread):
         self.db_lock = db_lock
         logging.info("Starting gatherer thread")
 
+    def remove_all_populators(self):
+        """
+        Stops all populators and clears the cached list.
+        """
+        # Faster if all threads are stopped first, then joined after.
+        for populator in self.instruments.values():
+            populator.running = False
+
+        self.wait_for_populators_to_finish()
+
+        self.instruments.clear()
+
+    def wait_for_populators_to_finish(self):
+        """
+        Blocks until all populators are finished.
+        """
+        [populator.join() for populator in self.instruments.values()]
+
     def run(self):
         while self.running:
             inst_list = list(map(lambda x: correct_name(x), self.inst_list))
             all_data = gather_all_data_and_format(inst_list)
-            print("All formatted data:")
-            print(all_data)
+            # print("All formatted data:")
+            # print(all_data)
 
             for inst in inst_list:
                 if inst["isScheduled"]:
@@ -51,8 +70,11 @@ class Gatherer(threading.Thread):
                     try:
                         new_populator = PopulatorOnly(name, host, self.db_lock, all_data, self.run_continuous)
                         new_populator.start()
+                        self.instruments[name] = new_populator
                     except Exception as e:
                         logging.error("Unable to connect to {}: {}".format(name, e))
+
+            self.remove_all_populators()
             if self.run_continuous:
                 for i in range(POLLING_TIME):
                     sleep(1)

--- a/exp_db_populator/gatherer.py
+++ b/exp_db_populator/gatherer.py
@@ -1,0 +1,62 @@
+from exp_db_populator.populator import Populator, PopulatorOnly
+from exp_db_populator.webservices_reader import gather_all_data_and_format
+from exp_db_populator.webservices_reader import gather_old_data
+import epics
+import zlib
+import json
+import threading
+import logging
+from time import sleep
+import pickle
+from logging.handlers import TimedRotatingFileHandler
+import os
+from six.moves import input
+import argparse
+
+POLLING_TIME = 30  # Time in seconds between polling the website
+
+
+def correct_name(old_name):
+    """
+    Some names are different between IBEX and the web data, this function converts these.
+    Args:
+        old_name: The IBEX name
+    Returns:
+        str: The web name
+    """
+    return "ENGIN-X" if old_name == "ENGINX" else old_name
+
+
+class Gatherer(threading.Thread):
+    running = True
+
+    def __init__(self, inst_list, db_lock, run_continuous=False):
+        threading.Thread.__init__(self)
+        self.daemon = True
+        self.inst_list = inst_list
+        self.run_continuous = run_continuous
+        self.db_lock = db_lock
+        logging.info("Starting gatherer thread")
+
+    def run(self):
+        while self.running:
+            inst_list = list(map(lambda x: correct_name(x), self.inst_list))
+            all_data = gather_all_data_and_format(inst_list)
+            print("All formatted data:")
+            print(all_data)
+
+            for inst in inst_list:
+                if inst["isScheduled"]:
+                    name, host = correct_name(inst["name"]), inst["hostName"]
+                    try:
+                        new_populator = PopulatorOnly(name, host, self.db_lock, all_data, self.run_continuous)
+                        new_populator.start()
+                    except Exception as e:
+                        logging.error("Unable to connect to {}: {}".format(name, e))
+            if self.run_continuous:
+                for i in range(POLLING_TIME):
+                    sleep(1)
+                    if not self.running:
+                        return
+            else:
+                break

--- a/exp_db_populator/gatherer.py
+++ b/exp_db_populator/gatherer.py
@@ -1,6 +1,5 @@
 from exp_db_populator.populator import Populator, PopulatorOnly
 from exp_db_populator.webservices_reader import gather_all_data_and_format
-from exp_db_populator.webservices_reader import gather_old_data
 import epics
 import zlib
 import json

--- a/exp_db_populator/gatherer.py
+++ b/exp_db_populator/gatherer.py
@@ -1,18 +1,10 @@
-from exp_db_populator.populator import Populator, PopulatorOnly
+from exp_db_populator.populator import PopulatorOnly
 from exp_db_populator.webservices_reader import gather_all_data_and_format
-import epics
-import zlib
-import json
 import threading
 import logging
 from time import sleep
-import pickle
-from logging.handlers import TimedRotatingFileHandler
-import os
-from six.moves import input
-import argparse
 
-POLLING_TIME = 60  # Time in seconds between polling the website
+POLLING_TIME = 3600  # Time in seconds between polling the website
 
 
 def correct_name(old_name):
@@ -35,12 +27,15 @@ class Gatherer(threading.Thread):
         self.inst_list = inst_list
         self.run_continuous = run_continuous
         self.db_lock = db_lock
-        logging.info("Starting gatherer thread")
+        logging.info("Starting gatherer")
 
     def run(self):
+        """
+        Periodically runs to gather new data and populate the databases.
+        """
         while self.running:
             inst_list = list(map(lambda x: correct_name(x), self.inst_list))
-            all_data = gather_all_data_and_format(inst_list)
+            all_data = gather_all_data_and_format()
 
             for inst in inst_list:
                 if inst["isScheduled"]:

--- a/exp_db_populator/gatherer.py
+++ b/exp_db_populator/gatherer.py
@@ -28,7 +28,6 @@ def correct_name(old_name):
 
 class Gatherer(threading.Thread):
     running = True
-    instruments = {}
 
     def __init__(self, inst_list, db_lock, run_continuous=False):
         threading.Thread.__init__(self)
@@ -38,42 +37,20 @@ class Gatherer(threading.Thread):
         self.db_lock = db_lock
         logging.info("Starting gatherer thread")
 
-    def remove_all_populators(self):
-        """
-        Stops all populators and clears the cached list.
-        """
-        # Faster if all threads are stopped first, then joined after.
-        for populator in self.instruments.values():
-            populator.running = False
-
-        self.wait_for_populators_to_finish()
-
-        self.instruments.clear()
-
-    def wait_for_populators_to_finish(self):
-        """
-        Blocks until all populators are finished.
-        """
-        [populator.join() for populator in self.instruments.values()]
-
     def run(self):
         while self.running:
             inst_list = list(map(lambda x: correct_name(x), self.inst_list))
             all_data = gather_all_data_and_format(inst_list)
-            # print("All formatted data:")
-            # print(all_data)
 
             for inst in inst_list:
                 if inst["isScheduled"]:
                     name, host = correct_name(inst["name"]), inst["hostName"]
                     try:
                         new_populator = PopulatorOnly(name, host, self.db_lock, all_data, self.run_continuous)
-                        new_populator.start()
-                        self.instruments[name] = new_populator
+                        new_populator.filter_and_populate()
                     except Exception as e:
                         logging.error("Unable to connect to {}: {}".format(name, e))
 
-            self.remove_all_populators()
             if self.run_continuous:
                 for i in range(POLLING_TIME):
                     sleep(1)

--- a/exp_db_populator/gatherer.py
+++ b/exp_db_populator/gatherer.py
@@ -18,19 +18,23 @@ def correct_name(old_name):
     return "ENGIN-X" if old_name == "ENGINX" else old_name
 
 
-def filter_instrument_data(data, inst_name):
+def filter_instrument_data(raw_data, inst_name):
     """
     Gets the data associated with the specified instrument.
     Args:
-        data: The data from the website
+        raw_data: All of the raw data from the website
         inst_name: The name of the instrument whose data you want to get
     Returns:
         list: The data associated with the specified instrument
     """
-    return list(filter(lambda x: x['instrument'] == inst_name, data))
+    return [x for x in raw_data if x['instrument'] == inst_name]
 
 
 class Gatherer(threading.Thread):
+    """
+    An instance of this class runs on a thread in the background.
+    Every hour, it gathers data from the website and sends it to all of the instruments.
+    """
     running = True
 
     def __init__(self, inst_list, db_lock, run_continuous=False):

--- a/exp_db_populator/gatherer.py
+++ b/exp_db_populator/gatherer.py
@@ -34,10 +34,9 @@ class Gatherer(threading.Thread):
         Periodically runs to gather new data and populate the databases.
         """
         while self.running:
-            inst_list = list(map(lambda x: correct_name(x), self.inst_list))
             all_data = gather_all_data_and_format()
 
-            for inst in inst_list:
+            for inst in self.inst_list:
                 if inst["isScheduled"]:
                     name, host = correct_name(inst["name"]), inst["hostName"]
                     try:

--- a/exp_db_populator/populator.py
+++ b/exp_db_populator/populator.py
@@ -12,8 +12,8 @@ try:
 except ImportError as e:
     logging.error("Password submodule not found, will not be able to write to databases")
 
-AGE_OF_EXPIRATION = 100 # How old (in days) the startdate of an experiment must be before it is removed from the database
-POLLING_TIME = 3600 # Time in seconds between polling the website
+AGE_OF_EXPIRATION = 100  # How old (in days) the startdate of an experiment must be before it is removed from the database
+POLLING_TIME = 3600  # Time in seconds between polling the website
 
 def remove_users_not_referenced():
     all_team_user_ids = Experimentteams.select(Experimentteams.userid)
@@ -172,9 +172,10 @@ class PopulatorOnly(threading.Thread):
         experiments, experiment_teams, rb_instrument = self.all_data
         experiments = list(filter(lambda x: rb_instrument[x[Experiment.experimentid]] == self.instrument_name, experiments))
         experiment_teams = list(filter(lambda x: rb_instrument[x.rb_number] == self.instrument_name, experiment_teams))
-        print("Filtered lists to populate:")
-        print(experiments)
-        print(experiment_teams)
+        # print("Filtered experiments list:")
+        # print(experiments)
+        # print("Filtered teams list:")
+        # print(experiment_teams)
         with self.db_lock:
             database_proxy.initialize(self.database)
             self.populate(experiments, experiment_teams)

--- a/exp_db_populator/populator.py
+++ b/exp_db_populator/populator.py
@@ -1,4 +1,4 @@
-from exp_db_populator.webservices_reader import gather_data_and_format, gather_all_data_and_format
+from exp_db_populator.webservices_reader import gather_data_and_format
 from exp_db_populator.database_model import User, Experiment, Experimentteams, database_proxy
 from exp_db_populator.data_types import CREDS_GROUP
 from datetime import datetime, timedelta
@@ -14,6 +14,7 @@ except ImportError as e:
 
 AGE_OF_EXPIRATION = 100  # How old (in days) the startdate of an experiment must be before it is removed from the database
 POLLING_TIME = 3600  # Time in seconds between polling the website
+
 
 def remove_users_not_referenced():
     all_team_user_ids = Experimentteams.select(Experimentteams.userid)

--- a/exp_db_populator/populator.py
+++ b/exp_db_populator/populator.py
@@ -66,14 +66,21 @@ def populate(experiments, experiment_teams):
         Experimentteams.insert_many(batch).on_conflict_ignore().execute()
 
 
-def update(instrument_name, instrument_host, db_lock, data, run_continuous=False):
+def update(instrument_name, instrument_host, db_lock, instrument_data, run_continuous=False):
     """
     Populates the database with this experiment's data.
+
+    Args:
+        instrument_name: The name of the instrument to update.
+        instrument_host: The host name of the instrument to update.
+        db_lock: A lock for writing to the database.
+        instrument_data: The data to send to the instrument.
+        run_continuous: Whether or not the program is running in continuous mode.
     """
     database = create_database(instrument_host)
     logging.info("Performing {} update for {}".format("hourly" if run_continuous else "single", instrument_name))
     try:
-        experiments, experiment_teams = data
+        experiments, experiment_teams = instrument_data
         with db_lock:
             database_proxy.initialize(database)
             populate(experiments, experiment_teams)

--- a/exp_db_populator/populator.py
+++ b/exp_db_populator/populator.py
@@ -1,9 +1,6 @@
-from exp_db_populator.webservices_reader import gather_data_and_format
 from exp_db_populator.database_model import User, Experiment, Experimentteams, database_proxy
 from exp_db_populator.data_types import CREDS_GROUP
 from datetime import datetime, timedelta
-import threading
-from time import sleep
 from peewee import MySQLDatabase, chunked
 import logging
 
@@ -36,165 +33,54 @@ def create_database(instrument_host):
     return MySQLDatabase("exp_data", user=username, password=password, host=instrument_host)
 
 
-class Populator(threading.Thread):
-    running = True
+def cleanup_old_data():
+    """
+    Removes old data from the database.
+    """
+    remove_old_experiment_teams(AGE_OF_EXPIRATION)
+    remove_experiments_not_referenced()
+    remove_users_not_referenced()
 
-    def __init__(self, instrument_name, instrument_host, db_lock, run_continuous=False):
-        threading.Thread.__init__(self)
-        self.daemon = True
-        self.instrument_host = instrument_host
-        self.instrument_name = instrument_name
-        self.database = create_database(instrument_host)
-        self.run_continuous = run_continuous
-        self.db_lock = db_lock
-        logging.info("Creating connection to {}".format(instrument_host))
 
-    def populate(self, experiments, experiment_teams):
-        """
-        Populates the database with experiment data.
+def populate(experiments, experiment_teams):
+    """
+    Populates the database with experiment data.
 
-        Args:
-            experiments (list[dict]): A list of dictionaries containing information on experiments.
-            experiment_teams (list[exp_db_populator.data_types.ExperimentTeamData]): A list containing the users for all new experiments.
-        """
-        if not experiments or not experiment_teams:
-            raise KeyError("Experiment without team or vice versa")
+    Args:
+        experiments (list[dict]): A list of dictionaries containing information on experiments.
+        experiment_teams (list[exp_db_populator.data_types.ExperimentTeamData]): A list containing the users for all new experiments.
+    """
+    if not experiments or not experiment_teams:
+        raise KeyError("Experiment without team or vice versa")
 
-        for batch in chunked(experiments, 100):
-            Experiment.insert_many(batch).on_conflict_replace().execute()
+    for batch in chunked(experiments, 100):
+        Experiment.insert_many(batch).on_conflict_replace().execute()
 
-        teams_update = [{Experimentteams.experimentid: exp_team.rb_number,
-                         Experimentteams.roleid: exp_team.role_id,
-                         Experimentteams.startdate: exp_team.start_date,
-                         Experimentteams.userid: exp_team.user.user_id}
-                        for exp_team in experiment_teams]
+    teams_update = [{Experimentteams.experimentid: exp_team.rb_number,
+                     Experimentteams.roleid: exp_team.role_id,
+                     Experimentteams.startdate: exp_team.start_date,
+                     Experimentteams.userid: exp_team.user.user_id}
+                    for exp_team in experiment_teams]
 
-        for batch in chunked(teams_update, 100):
-            Experimentteams.insert_many(batch).on_conflict_ignore().execute()
+    for batch in chunked(teams_update, 100):
+        Experimentteams.insert_many(batch).on_conflict_ignore().execute()
 
-    def cleanup_old_data(self):
-        """
-        Removes old data from the database.
-        """
-        remove_old_experiment_teams(AGE_OF_EXPIRATION)
-        remove_experiments_not_referenced()
-        remove_users_not_referenced()
 
-    def get_from_web_and_populate(self):
-        """
-        Gets the data from the web and populates the database.
-        """
-        experiments, experiment_teams = gather_data_and_format(self.instrument_name)
-        with self.db_lock:
-            database_proxy.initialize(self.database)
-            print(experiments, experiment_teams)
-            self.populate(experiments, experiment_teams)
-            self.cleanup_old_data()
+def update(instrument_name, instrument_host, db_lock, data, run_continuous=False):
+    """
+    Populates the database with this experiment's data.
+    """
+    database = create_database(instrument_host)
+    logging.info("Performing {} update for {}".format("hourly" if run_continuous else "single", instrument_name))
+    try:
+        experiments, experiment_teams = data
+        with db_lock:
+            database_proxy.initialize(database)
+            populate(experiments, experiment_teams)
+            cleanup_old_data()
             database_proxy.initialize(None)  # Ensure no other populators send to the wrong database
 
-    def run(self):
-        """
-        Periodically runs to populate the database.
-        """
-        while self.running:
-            logging.info("Performing {} update for {}".format("hourly" if self.run_continuous else "single",
-                                                              self.instrument_name))
-            try:
-                self.get_from_web_and_populate()
-                logging.info("{} experiment data updated successfully".format(self.instrument_name))
-            except Exception:
-                logging.exception("{} unable to populate database, will try again in {} seconds".format(
-                    self.instrument_name, POLLING_TIME))
-
-            if self.run_continuous:
-                for i in range(POLLING_TIME):
-                    sleep(1)
-                    if not self.running:
-                        return
-            else:
-                break
-
-
-class PopulatorOnly:
-
-    def __init__(self, instrument_name, instrument_host, db_lock, all_data, run_continuous=False):
-        self.daemon = True
-        self.instrument_host = instrument_host
-        self.instrument_name = instrument_name
-        self.database = create_database(instrument_host)
-        self.run_continuous = run_continuous
-        self.db_lock = db_lock
-        self.all_data = all_data
-        logging.info("Creating connection to {}".format(instrument_host))
-
-    def populate(self, experiments, experiment_teams):
-        """
-        Populates the database with experiment data.
-
-        Args:
-            experiments (list[dict]): A list of dictionaries containing information on experiments.
-            experiment_teams (list[exp_db_populator.data_types.ExperimentTeamData]): A list containing the users for all new experiments.
-        """
-        if not experiments or not experiment_teams:
-            raise KeyError("Experiment without team or vice versa")
-
-        for batch in chunked(experiments, 100):
-            Experiment.insert_many(batch).on_conflict_replace().execute()
-
-        teams_update = [{Experimentteams.experimentid: exp_team.rb_number,
-                         Experimentteams.roleid: exp_team.role_id,
-                         Experimentteams.startdate: exp_team.start_date,
-                         Experimentteams.userid: exp_team.user.user_id}
-                        for exp_team in experiment_teams]
-
-        for batch in chunked(teams_update, 100):
-            Experimentteams.insert_many(batch).on_conflict_ignore().execute()
-
-    def cleanup_old_data(self):
-        """
-        Removes old data from the database.
-        """
-        remove_old_experiment_teams(AGE_OF_EXPIRATION)
-        remove_experiments_not_referenced()
-        remove_users_not_referenced()
-
-    def filter_and_populate(self):
-        """
-        Populates the database with this experiment's data.
-        """
-        logging.info("Performing {} update for {}".format("hourly" if self.run_continuous else "single",
-                                                          self.instrument_name))
-        try:
-            experiments, experiment_teams, rb_instrument = self.all_data
-            experiments = self.filter_experiments(experiments, rb_instrument)
-            experiment_teams = self.filter_experiment_teams(experiment_teams, rb_instrument)
-            with self.db_lock:
-                database_proxy.initialize(self.database)
-                self.populate(experiments, experiment_teams)
-                self.cleanup_old_data()
-                database_proxy.initialize(None)  # Ensure no other populators send to the wrong database
-
-            logging.info("{} experiment data updated successfully".format(self.instrument_name))
-        except Exception:
-            logging.exception("{} unable to populate database, will try again in {} seconds".format(
-                self.instrument_name, POLLING_TIME))
-
-    def filter_experiments(self, experiments, rb_instrument):
-        """
-        Returns all of this instrument's experiments data.
-
-        Args:
-            experiments (list[dict]): A list of dictionaries containing information on experiments.
-            rb_instrument (dict): A dictionary which connects rb numbers with their associated experiment
-        """
-        return list(filter(lambda x: rb_instrument[x[Experiment.experimentid]] == self.instrument_name, experiments))
-
-    def filter_experiment_teams(self, experiment_teams, rb_instrument):
-        """
-        Returns all of this instrument's experiment teams data.
-
-        Args:
-            experiment_teams (list[exp_db_populator.data_types.ExperimentTeamData]): A list containing the users for all new experiments.
-            rb_instrument (dict): A dictionary which connects rb numbers with their associated experiment
-        """
-        return list(filter(lambda x: rb_instrument[x.rb_number] == self.instrument_name, experiment_teams))
+        logging.info("{} experiment data updated successfully".format(instrument_name))
+    except Exception:
+        logging.exception("{} unable to populate database, will try again in {} seconds".format(
+            instrument_name, POLLING_TIME))

--- a/exp_db_populator/webservices_reader.py
+++ b/exp_db_populator/webservices_reader.py
@@ -97,11 +97,11 @@ def create_exp_team(user, role, rb_number, date):
     return ExperimentTeamData(user, role, rb_number, date)
 
 
-def reformat_data(data_list):
+def reformat_data(instrument_data_list):
     """
     Reformats the data from the way the website returns it to the way the database wants it.
     Args:
-        data_list (list): List of all data returned by the website.
+        instrument_data_list (list): List of an instrument's data from the website.
 
     Returns:
         tuple (list, list): A list of the experiments and their associated data and a list of the experiment teams,
@@ -111,7 +111,7 @@ def reformat_data(data_list):
         experiments = []
         exp_teams = []
 
-        for data in data_list:
+        for data in instrument_data_list:
 
             experiments.append({Experiment.experimentid: data['rbNumber'],
                                 Experiment.startdate: data['scheduledDate'],

--- a/exp_db_populator/webservices_reader.py
+++ b/exp_db_populator/webservices_reader.py
@@ -121,48 +121,7 @@ def create_exp_team(user, role, rb_number, rb_start_dates):
     return [ExperimentTeamData(user, role, rb_number, date) for date in rb_start_dates[rb_number]]
 
 
-def reformat_data(teams, dates, local_contacts):
-    """
-    Reformats the data from the way the website returns it to the way the database wants it.
-    Args:
-        teams (list): List of teams related to an experiment .
-        dates (list): List of all of the experiments and their dates.
-        local_contacts (list): List of local contacts for all experiments.
-
-    Returns:
-        tuple (list, list): A list of the experiments and their associated data and a list of the experiment teams.
-                            Experiment teams contains information on each experiment and which users are related to it.
-    """
-    try:
-        rb_start_dates = {}
-        experiments = []
-        exp_teams = []
-
-        for date in dates:
-            experiments.append({Experiment.experimentid: date['rbNumber'],
-                                Experiment.startdate: date['scheduledDate'],
-                                Experiment.duration: math.ceil(date['timeAllocated'])})
-
-            rb_number = date['rbNumber']
-            date_for_rb = rb_start_dates.get(rb_number, [])
-            rb_start_dates[rb_number] = date_for_rb + [date['scheduledDate']]
-
-        for user in local_contacts:
-            user_data = UserData(user['name'], LOCAL_ORG)
-            exp_teams.extend(create_exp_team(user_data, "Contact", user['rbNumber'], rb_start_dates))
-
-        for team in teams:
-            for user in get_experimenters(team):
-                user_data = UserData(user['name'], user['organisation'])
-                exp_teams.extend(create_exp_team(user_data, user["role"], team['rbNumber'], rb_start_dates))
-
-        return experiments, exp_teams
-    except Exception:
-        logging.exception('Could not reformat data:')
-        raise
-
-
-def reformat_all_data(data_list):
+def reformat_data(data_list):
     """
     Reformats the data from the way the website returns it to the way the database wants it.
     Args:
@@ -212,5 +171,5 @@ def gather_data_and_format(instrument_name):
 def gather_all_data_and_format():
     client, session_id = connect()
     data = get_all_data_from_web(client, session_id)
-    return reformat_all_data(data)
+    return reformat_data(data)
 

--- a/exp_db_populator/webservices_reader.py
+++ b/exp_db_populator/webservices_reader.py
@@ -15,7 +15,7 @@ except ImportError as e:
 
 LOCAL_ORG = "Science and Technology Facilities Council"
 LOCAL_ROLE = "Contact"
-RELEVANT_DATE_RANGE = 100  # How many days of data to gather (either side of now)
+RELEVANT_DATE_RANGE = 10  # How many days of data to gather (either side of now)
 DATE_TIME_FORMAT = '%Y-%m-%dT%H:%M:%S'
 
 BUS_APPS_SITE = "https://fitbaweb1.isis.cclrc.ac.uk:8443/"
@@ -193,12 +193,5 @@ def gather_data_and_format(instrument_name):
 def gather_all_data_and_format(inst_list):
     client, session_id = connect()
     data = get_all_data_from_web(client, session_id)
-    # print("Data from BusApps:")
-    # print(data)
     return reformat_all_data(data)
-
-
-def gather_old_data():
-    client, session_id = connect()
-    return get_data_from_web("LARMOR", client, session_id)
 

--- a/exp_db_populator/webservices_reader.py
+++ b/exp_db_populator/webservices_reader.py
@@ -15,7 +15,7 @@ except ImportError as e:
 
 LOCAL_ORG = "Science and Technology Facilities Council"
 LOCAL_ROLE = "Contact"
-RELEVANT_DATE_RANGE = 1  # How many days of data to gather (either side of now)
+RELEVANT_DATE_RANGE = 100  # How many days of data to gather (either side of now)
 DATE_TIME_FORMAT = '%Y-%m-%dT%H:%M:%S'
 
 BUS_APPS_SITE = "https://fitbaweb1.isis.cclrc.ac.uk:8443/"
@@ -193,8 +193,8 @@ def gather_data_and_format(instrument_name):
 def gather_all_data_and_format(inst_list):
     client, session_id = connect()
     data = get_all_data_from_web(client, session_id)
-    print("Data from BusApps:")
-    print(data)
+    # print("Data from BusApps:")
+    # print(data)
     return reformat_all_data(data)
 
 

--- a/exp_db_populator/webservices_reader.py
+++ b/exp_db_populator/webservices_reader.py
@@ -15,7 +15,7 @@ except ImportError as e:
 
 LOCAL_ORG = "Science and Technology Facilities Council"
 LOCAL_ROLE = "Contact"
-RELEVANT_DATE_RANGE = 10  # How many days of data to gather (either side of now)
+RELEVANT_DATE_RANGE = 1  # How many days of data to gather (either side of now)
 DATE_TIME_FORMAT = '%Y-%m-%dT%H:%M:%S'
 
 BUS_APPS_SITE = "https://fitbaweb1.isis.cclrc.ac.uk:8443/"
@@ -91,9 +91,18 @@ def get_data_from_web(instrument, client, session_id):
 
 
 def get_all_data_from_web(client, session_id):
+    """
+    Args:
+        client: The client that has connected to the web.
+        session_id: The id of the web session.
+
+    Returns:
+        list: The data from the website
+    """
     try:
         date_range = create_date_range(client)
 
+        logging.info("Gathering updated experiment data from server")
         experiments = client.service.getExperimentsByDate(session_id, "ISIS", date_range)
         return experiments
     except Exception:
@@ -154,6 +163,16 @@ def reformat_data(teams, dates, local_contacts):
 
 
 def reformat_all_data(data_list):
+    """
+    Reformats the data from the way the website returns it to the way the database wants it.
+    Args:
+        data_list (list): List of all data returned by the website.
+
+    Returns:
+        tuple (list, list, dict): A list of the experiments and their associated data, a list of the experiment teams,
+                            and a dictionary of rb_numbers and their associated instrument.
+                            Experiment teams contains information on each experiment and which users are related to it.
+    """
     try:
         rb_start_dates = {}
         experiments = []
@@ -190,7 +209,7 @@ def gather_data_and_format(instrument_name):
     return reformat_data(teams, dates, local_contacts)
 
 
-def gather_all_data_and_format(inst_list):
+def gather_all_data_and_format():
     client, session_id = connect()
     data = get_all_data_from_web(client, session_id)
     return reformat_all_data(data)

--- a/main.py
+++ b/main.py
@@ -86,7 +86,6 @@ class InstrumentPopulatorRunner:
         Stops all gatherers and clears the cached list.
         """
         # Faster if all threads are stopped first, then joined after.
-        self.wait_for_populators_to_finish()
         for gatherer in self.gatherers:
             gatherer.running = False
 
@@ -101,19 +100,12 @@ class InstrumentPopulatorRunner:
             inst_list (dict): Information about all instruments.
         """
 
-        # Easiest way to make sure gatherer and populators are up to date is stop them all and start them again
+        # Easiest way to make sure gatherer is up to date is restart it
         self.remove_all_gatherers()
 
         gatherer = Gatherer(inst_list, self.db_lock, self.run_continuous)
         gatherer.start()
         self.gatherers.append(gatherer)
-
-    def wait_for_populators_to_finish(self):
-        """
-        Blocks until all populators are finished.
-        """
-        for gatherer in self.gatherers:
-            gatherer.remove_all_populators()
 
     def wait_for_gatherers_to_finish(self):
         """
@@ -153,4 +145,3 @@ if __name__ == '__main__':
                     logging.warning("Command not recognised: {}".format(menu_input))
     else:
         main.wait_for_gatherers_to_finish()
-        main.wait_for_populators_to_finish()

--- a/main.py
+++ b/main.py
@@ -42,17 +42,6 @@ def convert_inst_list(value_from_PV):
     return json.loads(json_string)
 
 
-def correct_name(old_name):
-    """
-    Some names are different between IBEX and the web data, this function converts these.
-    Args:
-        old_name: The IBEX name
-    Returns:
-        str: The web name
-    """
-    return "ENGIN-X" if old_name == "ENGINX" else old_name
-
-
 class InstrumentPopulatorRunner:
     """
     Responsible for managing the thread that will gather the data and populate each instrument.

--- a/main.py
+++ b/main.py
@@ -14,7 +14,7 @@ import argparse
 # PV that contains the instrument list
 INST_LIST_PV = "CS:INSTLIST"
 
-DEBUG = True
+DEBUG = False
 
 log_folder = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'logs')
 if not os.path.exists(log_folder):
@@ -95,7 +95,7 @@ class InstrumentPopulatorRunner:
         """
         Starts a new gatherer thread.
         Args:
-            inst_list (dict): Information about all instruments.
+            inst_list (list): Information about all instruments.
         """
 
         # Easiest way to make sure gatherer is up to date is to restart it

--- a/main.py
+++ b/main.py
@@ -7,7 +7,6 @@ import zlib
 import json
 import threading
 import logging
-import pickle
 from logging.handlers import TimedRotatingFileHandler
 import os
 from six.moves import input

--- a/tests/test_gatherer.py
+++ b/tests/test_gatherer.py
@@ -19,8 +19,7 @@ class GathererTests(unittest.TestCase):
 
         new_gatherer = Gatherer(inst_list, self.lock, False)
         new_gatherer.start()
-        sleep(0.5)
-        gather_data.assert_called()
+        new_gatherer.join()
 
         update.assert_called()
 
@@ -33,8 +32,7 @@ class GathererTests(unittest.TestCase):
 
         new_gatherer = Gatherer(inst_list, self.lock, False)
         new_gatherer.start()
-        sleep(0.5)
-        gather_data.assert_called()
+        new_gatherer.join()
 
         update.assert_not_called()
 

--- a/tests/test_gatherer.py
+++ b/tests/test_gatherer.py
@@ -1,160 +1,39 @@
 import unittest
-import exp_db_populator.database_model as model
-from peewee import SqliteDatabase
-from exp_db_populator.populator import remove_users_not_referenced, remove_old_experiment_teams, \
-    remove_experiments_not_referenced, Populator, PopulatorOnly
 from exp_db_populator.gatherer import Gatherer
-from tests.webservices_test_data import *
-from mock import Mock, patch
-from exp_db_populator.data_types import UserData, ExperimentTeamData
+from mock import patch
 from time import sleep
 import threading
 
 
-class PopulatorTests(unittest.TestCase):
+class GathererTests(unittest.TestCase):
 
     def setUp(self):
-        # Creates an in-memory database for testing
-        database = SqliteDatabase(":memory:")
-        model.database_proxy.initialize(database)
-        model.database_proxy.create_tables([model.User, model.Experimentteams, model.Experiment, model.Role])
-        self.role = model.Role.create(name=TEST_PI_ROLE, priority=1)
-
-        patch_db = patch('exp_db_populator.populator.create_database')
-        patch_db.return_value = database
-        patch_db.start()
-
         self.lock = threading.Lock()
-        # self.populator = PopulatorOnly(TEST_INSTRUMENT, "test_connection", self.lock, ())
-        self.populator = Populator(TEST_INSTRUMENT, "test_connection", self.lock)
-        self.gatherer = Gatherer(["TEST_INST"], self.lock)
 
-        self.addCleanup(patch_db.stop)
+    @patch('exp_db_populator.gatherer.PopulatorOnly')
+    @patch('exp_db_populator.gatherer.gather_all_data_and_format')
+    def test_GIVEN_instrument_list_has_scheduled_instrument_WHEN_gatherer_started_THEN_populator_created(self, get_data, pop):
+        new_name, new_host = "TEST", "NDXTEST"
+        inst_list = [{"name": new_name, "hostName": new_host, "isScheduled": True}]
+        get_data.return_value = ([], [], {})
 
-    def create_full_record(self, rb_number=TEST_RBNUMBER, user_name=TEST_USER_PI, startdate=TEST_DATE):
-        user = model.User.create(name=user_name, organisation="STFC")
-        exp = model.Experiment.create(duration=1, experimentid=rb_number, startdate=startdate)
-        model.Experimentteams.create(experimentid=exp.experimentid, roleid=self.role.roleid,
-                                     startdate=startdate, userid=user.userid)
-
-    def test_WHEN_populate_called_with_experiments_and_no_teams_THEN_exception_raised(self):
-        self.assertRaises(KeyError, self.populator.populate, ["TEST"], [])
-
-    def create_experiments_dictionary(self):
-        return [{model.Experiment.experimentid: TEST_RBNUMBER,
-                 model.Experiment.duration: TEST_TIMEALLOCATED,
-                 model.Experiment.startdate: TEST_DATE}]
-
-    def create_rb_instrument_dictionary(self):
-        return {TEST_RBNUMBER: TEST_INSTRUMENT}
-
-    def create_experiment_teams_dictionary(self):
-        exp_team_data = Mock(ExperimentTeamData)
-        exp_team_data.rb_number = TEST_RBNUMBER
-        exp_team_data.role_id = self.role.roleid
-        exp_team_data.start_date = TEST_DATE
-        exp_team_data.user = Mock(UserData)
-        exp_team_data.user.user_id = 1
-        return [exp_team_data]
-
-    def test_WHEN_populate_called_with_experiments_and_no_teams_THEN_exception_raised(self):
-        experiments = self.create_experiments_dictionary()
-        self.assertRaises(KeyError, self.populator.populate, experiments, [])
-
-    def test_WHEN_populate_called_with_teams_and_no_experiments_THEN_exception_raised(self):
-        experiment_teams = self.create_experiment_teams_dictionary()
-        self.assertRaises(KeyError, self.populator.populate, [], experiment_teams)
-
-    def test_WHEN_filter_experiments_called_with_experiment_belonging_to_instrument_THEN_experiment_accepted(self):
-        experiments = self.create_experiments_dictionary()
-        rb_instrument = self.create_rb_instrument_dictionary()
-        self.assertEqual(1, len(self.populator.filter_experiments(experiments, rb_instrument)))
-
-    def test_WHEN_filter_experiments_called_with_experiment_not_belonging_to_instrument_THEN_experiment_rejected(self):
-        experiments = self.create_experiments_dictionary()
-        rb_instrument = {TEST_RBNUMBER: TEST_OTHER_INSTRUMENT}
-        self.assertEqual(0, len(self.populator.filter_experiments(experiments, rb_instrument)))
-
-    def test_WHEN_filter_experiment_teams_called_with_team_belonging_to_instrument_THEN_team_accepted(self):
-        experiment_teams = self.create_experiment_teams_dictionary()
-        rb_instrument = self.create_rb_instrument_dictionary()
-        self.assertEqual(1, len(self.populator.filter_experiment_teams(experiment_teams, rb_instrument)))
-
-    def test_WHEN_filter_experiment_teams_called_with_team_not_belonging_to_instrument_THEN_team_rejected(self):
-        experiment_teams = self.create_experiment_teams_dictionary()
-        rb_instrument = {TEST_RBNUMBER: TEST_OTHER_INSTRUMENT}
-        self.assertEqual(0, len(self.populator.filter_experiment_teams(experiment_teams, rb_instrument)))
-
-    def test_WHEN_populate_called_with_list_of_experiments_and_teams_THEN_experiments__and_teams_database_populated(self):
-        experiments = self.create_experiments_dictionary()
-        experiment_teams = self.create_experiment_teams_dictionary()
-
-        db_experiments = model.Experiment.select()
-        db_experiment_teams = model.Experimentteams.select()
-
-        self.assertEqual(0, db_experiments.count())
-        self.assertEqual(0, db_experiment_teams.count())
-
-        self.populator.populate(experiments, experiment_teams)
-
-        self.assertEqual(1, db_experiments.count())
-        self.assertEqual(1, db_experiment_teams.count())
-
-    def test_GIVEN_experiment_already_exists_WHEN_populate_called_THEN_experiment_is_overriden(self):
-        model.Experiment.create(duration=5, experimentid=TEST_RBNUMBER, startdate=TEST_DATE)
-
-        experiments = self.create_experiments_dictionary()
-        experiment_teams = self.create_experiment_teams_dictionary()
-
-        self.assertNotEqual(TEST_TIMEALLOCATED, model.Experiment.select()[0].duration)
-
-        self.populator.populate(experiments, experiment_teams)
-
-        db_experiments = model.Experiment.select()
-        self.assertEqual(1, db_experiments.count())
-        self.assertEqual(TEST_TIMEALLOCATED, db_experiments[0].duration)
-
-    @patch('exp_db_populator.populator.gather_data_and_format')
-    def test_GIVEN_db_locked_WHEN_populator_running_THEN_does_not_write_to_db(self, gather):
-        gather.side_effect = lambda x: (x, x)
-
-        pop_populate = Mock()
-
-        self.populator.cleanup_old_data = lambda: sleep(1)
-        self.populator.populate = pop_populate
-
-        thread_one = threading.Thread(target=self.populator.get_from_web_and_populate)
-
-        with self.lock:
-            thread_one.start()
-            sleep(0.5)
-            gather.assert_called()
-            pop_populate.assert_not_called()
-
+        new_gatherer = Gatherer(inst_list, self.lock, False)
+        new_gatherer.start()
         sleep(0.5)
-        pop_populate.assert_called()
+        get_data.assert_called()
 
-    @patch('exp_db_populator.populator.gather_data_and_format')
-    def test_GIVEN_two_populators_WHEN_one_writing_to_database_THEN_the_other_does_not(self, gather):
-        gather.side_effect = lambda x: (x, x)
-        second_pop = Populator("SECOND_INST", "test_connection", self.lock)
+        pop.assert_called()
 
-        pop_populate = Mock()
+    @patch('exp_db_populator.gatherer.PopulatorOnly')
+    @patch('exp_db_populator.gatherer.gather_all_data_and_format')
+    def test_GIVEN_instrument_list_has_unscheduled_instrument_WHEN_gatherer_started_THEN_populator_not_started(self, get_data, pop):
+        new_name, new_host = "TEST", "NDXTEST"
+        inst_list = [{"name": new_name, "hostName": new_host, "isScheduled": False}]
+        get_data.return_value = ([], [], {})
 
-        self.populator.cleanup_old_data = lambda: sleep(0.5)
-        self.populator.populate = pop_populate
+        new_gatherer = Gatherer(inst_list, self.lock, False)
+        new_gatherer.start()
+        sleep(0.5)
+        get_data.assert_called()
 
-        second_pop.cleanup_old_data = Mock()
-        second_pop.populate = pop_populate
-
-        thread_one = threading.Thread(target=self.populator.get_from_web_and_populate)
-        thread_two = threading.Thread(target=second_pop.get_from_web_and_populate)
-
-        thread_one.start()
-        thread_two.start()
-
-        pop_populate.assert_called_once_with(self.populator.instrument_name, self.populator.instrument_name)
-
-        thread_one.join()
-        sleep(0.2)
-        pop_populate.assert_called_with("SECOND_INST", "SECOND_INST")
+        pop.assert_not_called()

--- a/tests/test_gatherer.py
+++ b/tests/test_gatherer.py
@@ -1,5 +1,5 @@
 import unittest
-from exp_db_populator.gatherer import Gatherer
+from exp_db_populator.gatherer import Gatherer, filter_instrument_data
 from mock import patch
 from time import sleep
 import threading
@@ -10,30 +10,41 @@ class GathererTests(unittest.TestCase):
     def setUp(self):
         self.lock = threading.Lock()
 
-    @patch('exp_db_populator.gatherer.PopulatorOnly')
-    @patch('exp_db_populator.gatherer.gather_all_data_and_format')
-    def test_GIVEN_instrument_list_has_scheduled_instrument_WHEN_gatherer_started_THEN_populator_created(self, get_data, pop):
+    @patch('exp_db_populator.gatherer.update')
+    @patch('exp_db_populator.gatherer.gather_data')
+    def test_GIVEN_instrument_list_has_scheduled_instrument_WHEN_gatherer_started_THEN_update_runs(self, gather_data, update):
         new_name, new_host = "TEST", "NDXTEST"
         inst_list = [{"name": new_name, "hostName": new_host, "isScheduled": True}]
-        get_data.return_value = ([], [], {})
+        gather_data.return_value = []
 
         new_gatherer = Gatherer(inst_list, self.lock, False)
         new_gatherer.start()
         sleep(0.5)
-        get_data.assert_called()
+        gather_data.assert_called()
 
-        pop.assert_called()
+        update.assert_called()
 
-    @patch('exp_db_populator.gatherer.PopulatorOnly')
-    @patch('exp_db_populator.gatherer.gather_all_data_and_format')
-    def test_GIVEN_instrument_list_has_unscheduled_instrument_WHEN_gatherer_started_THEN_populator_not_started(self, get_data, pop):
+    @patch('exp_db_populator.gatherer.update')
+    @patch('exp_db_populator.gatherer.gather_data')
+    def test_GIVEN_instrument_list_has_unscheduled_instrument_WHEN_gatherer_started_THEN_no_update(self, gather_data, update):
         new_name, new_host = "TEST", "NDXTEST"
         inst_list = [{"name": new_name, "hostName": new_host, "isScheduled": False}]
-        get_data.return_value = ([], [], {})
+        gather_data.return_value = []
 
         new_gatherer = Gatherer(inst_list, self.lock, False)
         new_gatherer.start()
         sleep(0.5)
-        get_data.assert_called()
+        gather_data.assert_called()
 
-        pop.assert_not_called()
+        update.assert_not_called()
+
+    def test_GIVEN_data_of_correct_instrument_WHEN_filter_called_THEN_data_accepted(self):
+        inst_name = "TEST_INSTRUMENT"
+        data_item = {'instrument': inst_name}
+        self.assertEqual(filter_instrument_data([data_item], inst_name), [data_item])
+
+    def test_GIVEN_data_of_other_instrument_WHEN_filter_called_THEN_data_rejected(self):
+        inst_name = "TEST_INSTRUMENT"
+        other_name = "OTHER_INSTRUMENT"
+        data_item = {'instrument': other_name}
+        self.assertEqual(filter_instrument_data([data_item], inst_name), [])

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -10,32 +10,31 @@ class MainTest(unittest.TestCase):
         self.inst_pop_runner = InstrumentPopulatorRunner()
 
     @patch('main.Gatherer')
-    def test_GIVEN_empty_list_of_gatherers_WHEN_instrument_list_has_new_instrument_THEN_new_gatherer(self, gatherer):
+    def test_GIVEN_no_gatherer_running_WHEN_instrument_list_has_new_instrument_THEN_gatherer_starts(self, gatherer):
         new_name, new_host = "TEST", "NDXTEST"
         new_gather = gatherer.return_value
 
         self.inst_pop_runner.inst_list_changes([{"name": new_name, "hostName": new_host, "isScheduled": True}])
 
-        self.assertEqual(1, len(self.inst_pop_runner.gatherers))
-        self.assertEqual(new_gather, self.inst_pop_runner.gatherers[0])
+        self.assertEqual(new_gather, self.inst_pop_runner.gatherer)
 
-    @patch('main.InstrumentPopulatorRunner.remove_all_gatherers')
+    @patch('main.InstrumentPopulatorRunner.remove_gatherer')
     def test_WHEN_instrument_list_updated_THEN_gatherer_stopped_and_cleared(self, stop):
         new_name, new_host = "TEST", "NDXTEST"
         self.inst_pop_runner.inst_list_changes([{"name": new_name, "hostName": new_host, "isScheduled": True}])
 
         stop.assert_called()
 
-    def test_GIVEN_existing_gatherer_WHEN_remove_all_called_THEN_gatherer_stopped_and_cleared(self):
+    def test_GIVEN_existing_gatherer_WHEN_remove_gatherer_called_THEN_gatherer_stopped_and_cleared(self):
         old_gatherer = Mock(Gatherer)
         old_gatherer.running = True
-        self.inst_pop_runner.gatherers.append(old_gatherer)
+        self.inst_pop_runner.gatherer = old_gatherer
 
-        self.inst_pop_runner.remove_all_gatherers()
+        self.inst_pop_runner.remove_gatherer()
 
         old_gatherer.join.assert_called()
         self.assertEqual(False, old_gatherer.running)
-        self.assertEqual(0, len(self.inst_pop_runner.gatherers))
+        self.assertEqual(None, self.inst_pop_runner.gatherer)
 
     # @patch('main.Populator')
     # def test_GIVEN_empty_list_of_populators_WHEN_instrument_list_has_new_instrument_THEN_added_to_populators(self, populator):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,44 +2,73 @@ import unittest
 from mock import patch, Mock
 from main import InstrumentPopulatorRunner
 from exp_db_populator.populator import Populator
+from exp_db_populator.gatherer import Gatherer
 
 
 class MainTest(unittest.TestCase):
     def setUp(self):
         self.inst_pop_runner = InstrumentPopulatorRunner()
 
-    @patch('main.Populator')
-    def test_GIVEN_empty_list_of_populators_WHEN_instrument_list_has_new_instrument_THEN_added_to_populators(self, populator):
+    @patch('main.Gatherer')
+    def test_GIVEN_empty_list_of_gatherers_WHEN_instrument_list_has_new_instrument_THEN_new_gatherer(self, gatherer):
         new_name, new_host = "TEST", "NDXTEST"
-        new_pop = populator.return_value
+        new_gather = gatherer.return_value
+
         self.inst_pop_runner.inst_list_changes([{"name": new_name, "hostName": new_host, "isScheduled": True}])
 
-        self.assertEqual(1, len(self.inst_pop_runner.instruments))
-        self.assertEqual(new_pop, self.inst_pop_runner.instruments[new_name])
+        self.assertEqual(1, len(self.inst_pop_runner.gatherers))
+        self.assertEqual(new_gather, self.inst_pop_runner.gatherers[0])
 
-    @patch('main.Populator')
-    def test_GIVEN_empty_list_of_populators_WHEN_instrument_list_has_new_unscheduled_instrument_THEN_not_added_to_populators(self, populator):
-        new_name, new_host = "TEST", "NDXTEST"
-        new_pop = populator.return_value
-        self.inst_pop_runner.inst_list_changes([{"name": new_name, "hostName": new_host, "isScheduled": False}])
-
-        self.assertEqual(0, len(self.inst_pop_runner.instruments))
-
-    @patch('main.Populator')
-    @patch('main.InstrumentPopulatorRunner.remove_all_populators')
-    def test_WHEN_instrument_list_updated_THEN_existing_stopped_and_cleared(self, populator, stop_all):
+    @patch('main.InstrumentPopulatorRunner.remove_all_gatherers')
+    def test_WHEN_instrument_list_updated_THEN_gatherer_stopped_and_cleared(self, stop):
         new_name, new_host = "TEST", "NDXTEST"
         self.inst_pop_runner.inst_list_changes([{"name": new_name, "hostName": new_host, "isScheduled": True}])
 
-        stop_all.assert_called()
+        stop.assert_called()
 
-    def test_GIVEN_existing_instruments_WHEN_remove_all_called_THEN_existing_stopped_and_cleared(self):
-        old_name, old_populator = "TEST", Mock(Populator)
-        old_populator.running = True
-        self.inst_pop_runner.instruments[old_name] = old_populator
+    def test_GIVEN_existing_gatherer_WHEN_remove_all_called_THEN_gatherer_stopped_and_cleared(self):
+        old_gatherer = Mock(Gatherer)
+        old_gatherer.running = True
+        self.inst_pop_runner.gatherers.append(old_gatherer)
 
-        self.inst_pop_runner.remove_all_populators()
+        self.inst_pop_runner.remove_all_gatherers()
 
-        old_populator.join.assert_called()
-        self.assertEqual(False, old_populator.running)
-        self.assertEqual(0, len(self.inst_pop_runner.instruments))
+        old_gatherer.join.assert_called()
+        self.assertEqual(False, old_gatherer.running)
+        self.assertEqual(0, len(self.inst_pop_runner.gatherers))
+
+    # @patch('main.Populator')
+    # def test_GIVEN_empty_list_of_populators_WHEN_instrument_list_has_new_instrument_THEN_added_to_populators(self, populator):
+    #     new_name, new_host = "TEST", "NDXTEST"
+    #     new_pop = populator.return_value
+    #     self.inst_pop_runner.inst_list_changes([{"name": new_name, "hostName": new_host, "isScheduled": True}])
+    #
+    #     self.assertEqual(1, len(self.inst_pop_runner.instruments))
+    #     self.assertEqual(new_pop, self.inst_pop_runner.instruments[new_name])
+
+    # @patch('main.Populator')
+    # def test_GIVEN_empty_list_of_populators_WHEN_instrument_list_has_new_unscheduled_instrument_THEN_not_added_to_populators(self, populator):
+    #     new_name, new_host = "TEST", "NDXTEST"
+    #     new_pop = populator.return_value
+    #     self.inst_pop_runner.inst_list_changes([{"name": new_name, "hostName": new_host, "isScheduled": False}])
+    #
+    #     self.assertEqual(0, len(self.inst_pop_runner.instruments))
+    #
+    # @patch('main.Populator')
+    # @patch('main.InstrumentPopulatorRunner.remove_all_populators')
+    # def test_WHEN_instrument_list_updated_THEN_existing_stopped_and_cleared(self, populator, stop_all):
+    #     new_name, new_host = "TEST", "NDXTEST"
+    #     self.inst_pop_runner.inst_list_changes([{"name": new_name, "hostName": new_host, "isScheduled": True}])
+    #
+    #     stop_all.assert_called()
+    #
+    # def test_GIVEN_existing_instruments_WHEN_remove_all_called_THEN_existing_stopped_and_cleared(self):
+    #     old_name, old_populator = "TEST", Mock(Populator)
+    #     old_populator.running = True
+    #     self.inst_pop_runner.instruments[old_name] = old_populator
+    #
+    #     self.inst_pop_runner.remove_all_populators()
+    #
+    #     old_populator.join.assert_called()
+    #     self.assertEqual(False, old_populator.running)
+    #     self.assertEqual(0, len(self.inst_pop_runner.instruments))

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,7 +1,6 @@
 import unittest
 from mock import patch, Mock
 from main import InstrumentPopulatorRunner
-from exp_db_populator.populator import Populator
 from exp_db_populator.gatherer import Gatherer
 
 
@@ -35,39 +34,3 @@ class MainTest(unittest.TestCase):
         old_gatherer.join.assert_called()
         self.assertEqual(False, old_gatherer.running)
         self.assertEqual(None, self.inst_pop_runner.gatherer)
-
-    # @patch('main.Populator')
-    # def test_GIVEN_empty_list_of_populators_WHEN_instrument_list_has_new_instrument_THEN_added_to_populators(self, populator):
-    #     new_name, new_host = "TEST", "NDXTEST"
-    #     new_pop = populator.return_value
-    #     self.inst_pop_runner.inst_list_changes([{"name": new_name, "hostName": new_host, "isScheduled": True}])
-    #
-    #     self.assertEqual(1, len(self.inst_pop_runner.instruments))
-    #     self.assertEqual(new_pop, self.inst_pop_runner.instruments[new_name])
-
-    # @patch('main.Populator')
-    # def test_GIVEN_empty_list_of_populators_WHEN_instrument_list_has_new_unscheduled_instrument_THEN_not_added_to_populators(self, populator):
-    #     new_name, new_host = "TEST", "NDXTEST"
-    #     new_pop = populator.return_value
-    #     self.inst_pop_runner.inst_list_changes([{"name": new_name, "hostName": new_host, "isScheduled": False}])
-    #
-    #     self.assertEqual(0, len(self.inst_pop_runner.instruments))
-    #
-    # @patch('main.Populator')
-    # @patch('main.InstrumentPopulatorRunner.remove_all_populators')
-    # def test_WHEN_instrument_list_updated_THEN_existing_stopped_and_cleared(self, populator, stop_all):
-    #     new_name, new_host = "TEST", "NDXTEST"
-    #     self.inst_pop_runner.inst_list_changes([{"name": new_name, "hostName": new_host, "isScheduled": True}])
-    #
-    #     stop_all.assert_called()
-    #
-    # def test_GIVEN_existing_instruments_WHEN_remove_all_called_THEN_existing_stopped_and_cleared(self):
-    #     old_name, old_populator = "TEST", Mock(Populator)
-    #     old_populator.running = True
-    #     self.inst_pop_runner.instruments[old_name] = old_populator
-    #
-    #     self.inst_pop_runner.remove_all_populators()
-    #
-    #     old_populator.join.assert_called()
-    #     self.assertEqual(False, old_populator.running)
-    #     self.assertEqual(0, len(self.inst_pop_runner.instruments))

--- a/tests/test_populator.py
+++ b/tests/test_populator.py
@@ -177,8 +177,8 @@ class PopulatorTests(unittest.TestCase):
         remove_old_experiment_teams(1)
         self.assertEqual(1, model.Experimentteams.select().count())
 
-    @patch('exp_db_populator.populator.PopulatorOnly.filter_experiments')
     @patch('exp_db_populator.populator.PopulatorOnly.filter_experiment_teams')
+    @patch('exp_db_populator.populator.PopulatorOnly.filter_experiments')
     def test_GIVEN_db_locked_WHEN_populator_running_THEN_does_not_write_to_db(self, experiments_filter, experiment_teams_filter):
         experiments_filter.side_effect = lambda x, y: x
         experiment_teams_filter.side_effect = lambda x, y: x

--- a/tests/test_populator.py
+++ b/tests/test_populator.py
@@ -159,8 +159,8 @@ class PopulatorTests(unittest.TestCase):
     @patch('exp_db_populator.populator.populate')
     @patch('exp_db_populator.populator.cleanup_old_data')
     def test_GIVEN_db_locked_WHEN_populate_runs_THEN_does_not_write_to_db(self, clean, pop):
-        clean.side_effect = lambda: sleep(1)
-        pop.side_effect = lambda x, y: sleep(0.5)
+        clean.side_effect = lambda: 0
+        pop.side_effect = lambda x, y: 0
 
         thread_one = threading.Thread(target=update, args=("", "", self.lock, ([], [])))
 
@@ -169,5 +169,5 @@ class PopulatorTests(unittest.TestCase):
             sleep(0.5)
             pop.assert_not_called()
 
-        sleep(0.5)
+        thread_one.join()
         pop.assert_called()

--- a/tests/webservices_test_data.py
+++ b/tests/webservices_test_data.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from mock import MagicMock, PropertyMock
 TEST_INSTRUMENT = 'test_instrument'
+TEST_OTHER_INSTRUMENT = "test_other_instrument"
 TEST_RBNUMBER = '10000'
 TEST_TIMEALLOCATED = 7
 TEST_DATE = datetime(2018, 1, 1)

--- a/tests/webservices_test_data.py
+++ b/tests/webservices_test_data.py
@@ -36,3 +36,10 @@ def get_test_experiment_team(experimenters):
     team.experimenters = experimenters
     team.__getitem__.side_effect = team_dict.__getitem__
     return team
+
+
+def create_data(rb, start, duration):
+    return {'instrument': TEST_INSTRUMENT, 'lcName': TEST_CONTACT_NAME, 'part': 6, 'rbNumber': rb, 'scheduledDate': start, 'timeAllocated': duration}
+
+
+TEST_DATA = [create_data(TEST_RBNUMBER, TEST_DATE, TEST_TIMEALLOCATED)]

--- a/tests/webservices_test_data.py
+++ b/tests/webservices_test_data.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from mock import MagicMock, PropertyMock
+from mock import MagicMock
 TEST_INSTRUMENT = 'test_instrument'
 TEST_OTHER_INSTRUMENT = "test_other_instrument"
 TEST_RBNUMBER = '10000'
@@ -19,10 +19,6 @@ TEST_PI_ROLE = 'PI'
 TEST_USER_1 = {'name': TEST_USER_1_NAME, 'organisation': TEST_USER_1_ORG, 'role': TEST_USER_1_ROLE}
 TEST_USER_PI = {'name': TEST_PI_NAME, 'organisation': TEST_PI_ORG, 'role': TEST_PI_ROLE}
 
-def create_date_data(rb, start, duration):
-    return {'instrument': TEST_INSTRUMENT, 'part': 6, 'rbNumber': rb, 'scheduledDate': start, 'timeAllocated': duration}
-
-TEST_DATES = [create_date_data(TEST_RBNUMBER, TEST_DATE, TEST_TIMEALLOCATED)]
 
 TEST_CONTACTS = [{'instrument': TEST_INSTRUMENT, 'name': TEST_CONTACT_NAME,
                   'rbNumber': TEST_RBNUMBER}]
@@ -43,3 +39,21 @@ def create_data(rb, start, duration):
 
 
 TEST_DATA = [create_data(TEST_RBNUMBER, TEST_DATE, TEST_TIMEALLOCATED)]
+
+
+def create_web_data_with_experimenters(experimenters):
+    data_dict = create_data(TEST_RBNUMBER, TEST_DATE, TEST_TIMEALLOCATED)
+
+    data = MagicMock()
+    data.experimenters = experimenters
+    data.__getitem__.side_effect = data_dict.__getitem__
+    return data
+
+
+def create_web_data_with_experimenters_and_other_date(experimenters, date):
+    data_dict = create_data(TEST_RBNUMBER, date, TEST_TIMEALLOCATED)
+
+    data = MagicMock()
+    data.experimenters = experimenters
+    data.__getitem__.side_effect = data_dict.__getitem__
+    return data


### PR DESCRIPTION
### Description of work

Reformatted to reduce number of calls to BusApps from (number_of_instruments * 3) per hour to 1 per hour. Previously there was a thread running for each instrument, now there is only one which populates all instruments every hour (no more multi-threading). The program is hopefully simpler now.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/4408

### Acceptance criteria

Set debug mode to True for testing.
- [ ] Calls BusApps much less
- [ ] Program behaves functionally identically to the previous version

### Unit tests

Adapted existing tests to work with the refactored code. Removed unnecessary tests and added some new ones.

### Documentation

https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Experimental-Database
The functionality hasn't changed, so I haven't needed to update the documentation.

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

