### PR TITLE
Ticket6465 error on crisp and surf

### DIFF
--- a/exp_db_populator/gatherer.py
+++ b/exp_db_populator/gatherer.py
@@ -1,4 +1,4 @@
-from exp_db_populator.populator import update, empty_update
+from exp_db_populator.populator import update
 from exp_db_populator.webservices_reader import gather_data, reformat_data
 import threading
 import logging
@@ -56,12 +56,10 @@ class Gatherer(threading.Thread):
                     name, host = correct_name(inst["name"]), inst["hostName"]
                     instrument_list = filter_instrument_data(all_data, name)
                     if not instrument_list:
-                        try:
-                            empty_update(name, host, self.db_lock)
-                        except Exception as e:
-                            logging.error("Unable to connect to {}: {}".format(name, e))
-                        continue
-                    data_to_populate = reformat_data(instrument_list)
+                        logging.error(f"Unable to update {name}, no data found. Expired data will still be cleared.")
+                        data_to_populate = None
+                    else:
+                        data_to_populate = reformat_data(instrument_list)
                     try:
                         update(name, host, self.db_lock, data_to_populate, self.run_continuous)
                     except Exception as e:

--- a/exp_db_populator/gatherer.py
+++ b/exp_db_populator/gatherer.py
@@ -1,4 +1,4 @@
-from exp_db_populator.populator import update
+from exp_db_populator.populator import update, empty_update
 from exp_db_populator.webservices_reader import gather_data, reformat_data
 import threading
 import logging
@@ -56,7 +56,10 @@ class Gatherer(threading.Thread):
                     name, host = correct_name(inst["name"]), inst["hostName"]
                     instrument_list = filter_instrument_data(all_data, name)
                     if not instrument_list:
-                        logging.error("Unable to update {}, no data found.".format(name))
+                        try:
+                            empty_update(name, host, self.db_lock)
+                        except Exception as e:
+                            logging.error("Unable to connect to {}: {}".format(name, e))
                         continue
                     data_to_populate = reformat_data(instrument_list)
                     try:

--- a/exp_db_populator/gatherer.py
+++ b/exp_db_populator/gatherer.py
@@ -51,11 +51,14 @@ class Gatherer(threading.Thread):
         """
         while self.running:
             all_data = gather_data()
-
             for inst in self.inst_list:
                 if inst["isScheduled"]:
                     name, host = correct_name(inst["name"]), inst["hostName"]
-                    data_to_populate = reformat_data(filter_instrument_data(all_data, name))
+                    instrument_list = filter_instrument_data(all_data, name)
+                    if not instrument_list:
+                        logging.error("Unable to update {}, no data found.".format(name))
+                        continue
+                    data_to_populate = reformat_data(instrument_list)
                     try:
                         update(name, host, self.db_lock, data_to_populate, self.run_continuous)
                     except Exception as e:

--- a/exp_db_populator/populator.py
+++ b/exp_db_populator/populator.py
@@ -66,30 +66,6 @@ def populate(experiments, experiment_teams):
         Experimentteams.insert_many(batch).on_conflict_ignore().execute()
 
 
-def empty_update(instrument_name, instrument_host, db_lock):
-    """
-        Handles Removing out of date data if there is nothing to update.
-
-        Args:
-            instrument_name: The name of the instrument to update.
-            instrument_host: The host name of the instrument to update.
-            db_lock: A lock for writing to the database.
-        """
-    database = create_database(instrument_host)
-    logging.error(
-        "Unable to update {}, no data found. Expired data will still be cleared.".format(instrument_name))
-    logging.info("Clearing expired data for {}".format(instrument_name))
-    try:
-        with db_lock:
-            database_proxy.initialize(database)
-            cleanup_old_data()
-            database_proxy.initialize(None)  # Ensure no other populators send to the wrong database
-        logging.info("{} experiment data cleared successfully".format(instrument_name))
-    except Exception:
-        logging.exception("{} unable to clear database, will try again in {} seconds".format(
-            instrument_name, POLLING_TIME))
-
-
 def update(instrument_name, instrument_host, db_lock, instrument_data, run_continuous=False):
     """
     Populates the database with this experiment's data.
@@ -98,16 +74,17 @@ def update(instrument_name, instrument_host, db_lock, instrument_data, run_conti
         instrument_name: The name of the instrument to update.
         instrument_host: The host name of the instrument to update.
         db_lock: A lock for writing to the database.
-        instrument_data: The data to send to the instrument.
+        instrument_data: The data to send to the instrument, if None the data will just be cleared instead.
         run_continuous: Whether or not the program is running in continuous mode.
     """
     database = create_database(instrument_host)
     logging.info("Performing {} update for {}".format("hourly" if run_continuous else "single", instrument_name))
     try:
-        experiments, experiment_teams = instrument_data
         with db_lock:
             database_proxy.initialize(database)
-            populate(experiments, experiment_teams)
+            if instrument_data is not None:
+                experiments, experiment_teams = instrument_data
+                populate(experiments, experiment_teams)
             cleanup_old_data()
             database_proxy.initialize(None)  # Ensure no other populators send to the wrong database
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ mock
 xmlrunner
 pyepics
 six
+cryptography

--- a/tests/test_gatherer.py
+++ b/tests/test_gatherer.py
@@ -12,10 +12,16 @@ class GathererTests(unittest.TestCase):
 
     @patch('exp_db_populator.gatherer.update')
     @patch('exp_db_populator.gatherer.gather_data')
-    def test_GIVEN_instrument_list_has_scheduled_instrument_WHEN_gatherer_started_THEN_update_runs(self, gather_data, update):
+    def test_GIVEN_instrument_list_has_scheduled_instrument_WHEN_gatherer_started_THEN_update_runs(self, gather_data,
+                                                                                                   update):
         new_name, new_host = "TEST", "NDXTEST"
         inst_list = [{"name": new_name, "hostName": new_host, "isScheduled": True}]
-        gather_data.return_value = []
+        gather_data.return_value = [{'instrument': "TEST",
+                                     'rbNumber': 1,
+                                     'scheduledDate': "1-1-1",
+                                     'timeAllocated': 1,
+                                     'lcName': "TEST",
+                                     }]
 
         new_gatherer = Gatherer(inst_list, self.lock, False)
         new_gatherer.start()
@@ -25,7 +31,35 @@ class GathererTests(unittest.TestCase):
 
     @patch('exp_db_populator.gatherer.update')
     @patch('exp_db_populator.gatherer.gather_data')
-    def test_GIVEN_instrument_list_has_unscheduled_instrument_WHEN_gatherer_started_THEN_no_update(self, gather_data, update):
+    def test_GIVEN_no_data_WHEN_gatherer_started_THEN_no_update(self, gather_data, update):
+        new_name, new_host = "TEST", "NDXTEST"
+        inst_list = [{"name": new_name, "hostName": new_host, "isScheduled": True}]
+        gather_data.return_value = []
+
+        new_gatherer = Gatherer(inst_list, self.lock, False)
+        new_gatherer.start()
+        new_gatherer.join()
+
+        update.assert_not_called()
+
+    @patch('exp_db_populator.gatherer.update')
+    @patch('exp_db_populator.gatherer.gather_data')
+    def test_GIVEN_instrument_list_has_unscheduled_instrument_WHEN_gatherer_started_THEN_no_update(self, gather_data,
+                                                                                                   update):
+        new_name, new_host = "TEST", "NDXTEST"
+        inst_list = [{"name": new_name, "hostName": new_host, "isScheduled": False}]
+        gather_data.return_value = []
+
+        new_gatherer = Gatherer(inst_list, self.lock, False)
+        new_gatherer.start()
+        new_gatherer.join()
+
+        update.assert_not_called()
+
+    @patch('exp_db_populator.gatherer.update')
+    @patch('exp_db_populator.gatherer.gather_data')
+    def test_GIVEN_instrument_list_has_unscheduled_instrument_WHEN_gatherer_started_THEN_no_update(self, gather_data,
+                                                                                                   update):
         new_name, new_host = "TEST", "NDXTEST"
         inst_list = [{"name": new_name, "hostName": new_host, "isScheduled": False}]
         gather_data.return_value = []

--- a/tests/test_gatherer.py
+++ b/tests/test_gatherer.py
@@ -58,20 +58,6 @@ class GathererTests(unittest.TestCase):
 
         update.assert_not_called()
 
-    @patch('exp_db_populator.gatherer.update')
-    @patch('exp_db_populator.gatherer.gather_data')
-    def test_GIVEN_instrument_list_has_unscheduled_instrument_WHEN_gatherer_started_THEN_no_update(self, gather_data,
-                                                                                                   update):
-        new_name, new_host = "TEST", "NDXTEST"
-        inst_list = [{"name": new_name, "hostName": new_host, "isScheduled": False}]
-        gather_data.return_value = []
-
-        new_gatherer = Gatherer(inst_list, self.lock, False)
-        new_gatherer.start()
-        new_gatherer.join()
-
-        update.assert_not_called()
-
     def test_GIVEN_data_of_correct_instrument_WHEN_filter_called_THEN_data_accepted(self):
         inst_name = "TEST_INSTRUMENT"
         data_item = {'instrument': inst_name}

--- a/tests/test_gatherer.py
+++ b/tests/test_gatherer.py
@@ -30,8 +30,9 @@ class GathererTests(unittest.TestCase):
         update.assert_called()
 
     @patch('exp_db_populator.gatherer.update')
+    @patch('exp_db_populator.gatherer.empty_update')
     @patch('exp_db_populator.gatherer.gather_data')
-    def test_GIVEN_no_data_WHEN_gatherer_started_THEN_no_update(self, gather_data, update):
+    def test_GIVEN_no_data_WHEN_gatherer_started_THEN_no_update(self, gather_data, empty_update, update):
         new_name, new_host = "TEST", "NDXTEST"
         inst_list = [{"name": new_name, "hostName": new_host, "isScheduled": True}]
         gather_data.return_value = []
@@ -41,6 +42,7 @@ class GathererTests(unittest.TestCase):
         new_gatherer.join()
 
         update.assert_not_called()
+        empty_update.assert_called()
 
     @patch('exp_db_populator.gatherer.update')
     @patch('exp_db_populator.gatherer.gather_data')

--- a/tests/test_gatherer.py
+++ b/tests/test_gatherer.py
@@ -30,9 +30,8 @@ class GathererTests(unittest.TestCase):
         update.assert_called()
 
     @patch('exp_db_populator.gatherer.update')
-    @patch('exp_db_populator.gatherer.empty_update')
     @patch('exp_db_populator.gatherer.gather_data')
-    def test_GIVEN_no_data_WHEN_gatherer_started_THEN_no_update(self, gather_data, empty_update, update):
+    def test_GIVEN_no_data_WHEN_gatherer_started_THEN_no_update(self, gather_data, update):
         new_name, new_host = "TEST", "NDXTEST"
         inst_list = [{"name": new_name, "hostName": new_host, "isScheduled": True}]
         gather_data.return_value = []
@@ -41,8 +40,7 @@ class GathererTests(unittest.TestCase):
         new_gatherer.start()
         new_gatherer.join()
 
-        update.assert_not_called()
-        empty_update.assert_called()
+        update.assert_called_with(new_name, new_host, self.lock, None, False)
 
     @patch('exp_db_populator.gatherer.update')
     @patch('exp_db_populator.gatherer.gather_data')


### PR DESCRIPTION
https://github.com/ISISComputingGroup/IBEX/issues/6465
CRISP, SURF, and INES were erroring due to 2 different problems.
SURF's issue has been resolved by adding cryptography to the requirments of the database populator.
CRISP and INES were erroring due to having no data. It has now been made more clear when lack of data is the reason that the database populator fails.

to test:
run the databse populator in debug mode, on CRISP, SURF, and INES. Enusring that SURF runs properly, and CRISP and INES give the following error `[ERROR] Unable to update INSTRUMENT_NAME, no data found.`