### PR TITLE
Disallow cloning submodules

### DIFF
--- a/.github/workflows/Lint-and-test.yml
+++ b/.github/workflows/Lint-and-test.yml
@@ -6,6 +6,7 @@ jobs:
     with:
       compare-branch: origin/master
       python-ver: '3.11'
+      clone-submodule: false
   tests:
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
This one attempts to avoid cloning the passwords submodule during checkout for linters